### PR TITLE
Added optional argument for insecure(variable) at code for Arista device

### DIFF
--- a/napalm/gnmi/gnmi.py
+++ b/napalm/gnmi/gnmi.py
@@ -94,8 +94,9 @@ class gNMIDriver(NetworkDriver):
 
         self.platform = "gnmi" # TODO auto-detect: cEOS or SR Linux
         self.port = optional_args.get("port", 57400)
+        self.insecure = optional_args.get("insecure", False)
         self.profile = [self.platform]
-
+        
         self._process_optional_args(optional_args or {})
 
     def _process_optional_args(self, optional_args):
@@ -113,7 +114,7 @@ class gNMIDriver(NetworkDriver):
                 username=self.username,
                 password=self.password,
                 gnmi_timeout=self.timeout,
-                insecure=False # hardcoded, TODO parameter
+                insecure=(self.insecure) # hardcoded, TODO parameter
                 # **self.eapi_kwargs
             )
 


### PR DESCRIPTION
1) In a dictionary, insecure(key) is changed to self.insecure(value)(Passing Value as optional Argument using argparse).
2) On Argparse, I added an insecure(variable) as an optional argument with default as True.
3) Arista device(n84_hackaton-ceos2) uses port 6030. Which is insecure. So, we made this change.

Sample Command with Optional Argument:
napalm -o port=6030,insecure=True --vendor gnmi --user admin --password admin clab-n84_hackathon-ceos2 call get_facts

Sample Output:
{
    "hostname": "ceos2",
    "fqdn": "ceos2",
    "vendor": "arista"
}